### PR TITLE
fixed class Media to try extract file_size field

### DIFF
--- a/main.py
+++ b/main.py
@@ -133,8 +133,6 @@ def main():
                        "Latitude: " + str(location.latitude))
             except (AttributeError, IndexError):
                 pass
-            else:
-                pass
 
             try:
                 sticker = 'BQADAgADQAADyIsGAAGMQCvHaYLU_AI'
@@ -161,6 +159,8 @@ def main():
 
             except (AttributeError, IndexError):
                 pass
+        else:
+            pass
     except AttributeError:
         pass
 

--- a/telegrambot.py
+++ b/telegrambot.py
@@ -463,8 +463,11 @@ class Media(object):
     def from_json(self, media):
 
         self.file_id = media['file_id']
-        self.file_size = media['file_size']
 
+        try:
+            self.file_size = media['file_size']
+        except KeyError:
+            pass
         try:
             self.mime_type = media['mime_type']
         except KeyError:


### PR DESCRIPTION
Sticker class was not working properly, because lack of field "file_size" in response from server, that was passed to class method from_json(). Sticker() inherits Media() and uses it's corresponding method with super() call. Because Media did not contain specific exception handler for field "file_size", return from "from_json" method was processed silently by exception handler in Message().from_json. As result, sticker object was returned with blank fields.
